### PR TITLE
Add --include-threads flag for thread activity detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ slack-cli channel new                Create a channel
 slack-cli channel invite             Invite users to a channel
 
 slack-cli message get <target>       Fetch a single message
-slack-cli message list <target>      List channel messages or thread
+slack-cli message list <target>      List channel messages, thread, or activity
 slack-cli message send <target>      Send a message
 slack-cli message edit <target>      Edit a message
 slack-cli message delete <target>    Delete a message

--- a/SLACK_CLI_USAGE.md
+++ b/SLACK_CLI_USAGE.md
@@ -38,6 +38,7 @@ Messages are returned in chronological order (oldest first). Each message includ
 - `ts` — unique timestamp identifier
 - `thread_ts` — present if the message is part of a thread
 - `reply_count` — number of thread replies (only on thread root messages, omitted when 0)
+- `latest_reply` — timestamp of the most recent reply (only on thread root messages)
 - `author.user_id` — who sent it
 - `content` — message text
 - `files` — attached file metadata (if any)
@@ -60,7 +61,23 @@ slack-cli message list '#channel-name' --oldest 1772200000.000000 --limit 50
 
 To compute a timestamp for "N seconds ago", subtract from the current unix epoch.
 
-### 5. Get a single message
+### 5. Check for all new activity (including threads)
+
+`--oldest` alone only returns new **top-level** messages. To also catch new replies in existing threads, add `--include-threads`:
+
+```
+slack-cli message list '#channel-name' --oldest 1772200000.000000 --limit 50 --include-threads
+```
+
+This scans the last `--limit` messages and fetches new thread replies for any thread with activity after `--oldest`. Output includes:
+- `messages` — new top-level messages (same as without the flag)
+- `thread_updates` — threads with new replies, each containing:
+  - `thread_ts` — the thread root timestamp
+  - `parent_author` — who started the thread
+  - `parent_preview` — truncated text of the thread root message
+  - `new_replies` — only the replies posted after `--oldest`
+
+### 6. Get a single message
 
 By Slack URL:
 
@@ -74,7 +91,7 @@ By channel + timestamp:
 slack-cli message get '#channel-name' --ts 1772065778.676219
 ```
 
-### 6. Resolve user IDs to names
+### 7. Resolve user IDs to names
 
 Messages contain user IDs (e.g. `U06JYRAKH9A`), not display names. Resolve them:
 
@@ -90,7 +107,7 @@ To list all workspace users:
 slack-cli user list --limit 200
 ```
 
-### 7. Search messages
+### 8. Search messages
 
 ```
 slack-cli search messages 'keyword' --limit 20
@@ -102,7 +119,7 @@ Filter by channel, user, or date range:
 slack-cli search messages 'deploy' --channel '#engineering' --user '@jules' --after 2026-02-01 --before 2026-02-28
 ```
 
-### 8. Search files
+### 9. Search files
 
 ```
 slack-cli search files 'report' --limit 10
@@ -167,9 +184,10 @@ slack-cli channel invite --channel '#channel-name' --users 'U01234,U56789'
 1. `slack-cli channel list` — discover available channels
 2. `slack-cli message list '#channel' --limit 25` — read recent activity
 3. For any message with `reply_count > 0` — `slack-cli message list '#channel' --thread-ts <ts>` to read the thread
-4. `slack-cli user get <user_id>` — resolve user IDs as needed
-5. `slack-cli message send '#channel' 'response'` — reply to the channel
-6. `slack-cli message send '#channel' 'response' --thread-ts <ts>` — reply in a specific thread
+4. To poll for new activity since a known timestamp — `slack-cli message list '#channel' --oldest <ts> --include-threads` to catch both new messages and new thread replies
+5. `slack-cli user get <user_id>` — resolve user IDs as needed
+6. `slack-cli message send '#channel' 'response'` — reply to the channel
+7. `slack-cli message send '#channel' 'response' --thread-ts <ts>` — reply in a specific thread
 
 ## Notes
 

--- a/cmd/message.go
+++ b/cmd/message.go
@@ -64,6 +64,7 @@ var messageListCmd = &cobra.Command{
 		latest, _ := cmd.Flags().GetString("latest")
 		maxBody, _ := cmd.Flags().GetInt("max-body-chars")
 		includeReactions, _ := cmd.Flags().GetBool("include-reactions")
+		includeThreads, _ := cmd.Flags().GetBool("include-threads")
 
 		target := urlparse.ParseMsgTarget(args[0])
 		client, err := getClient()
@@ -99,6 +100,29 @@ var messageListCmd = &cobra.Command{
 				"thread_ts":  effectiveThreadTS,
 				"messages":   messages,
 			})
+		}
+
+		// Activity mode: find new top-level messages AND new thread replies
+		if includeThreads && oldest != "" {
+			newMessages, threadUpdates, err := slack.FetchChannelActivity(cmd.Context(), client, slack.ChannelHistoryOpts{
+				ChannelID:        channelID,
+				Limit:            limit,
+				Oldest:           oldest,
+				Latest:           latest,
+				IncludeReactions: includeReactions,
+				MaxBodyChars:     maxBody,
+			})
+			if err != nil {
+				return err
+			}
+			result := map[string]interface{}{
+				"channel_id": channelID,
+				"messages":   newMessages,
+			}
+			if len(threadUpdates) > 0 {
+				result["thread_updates"] = threadUpdates
+			}
+			return output.PrintJSON(result)
 		}
 
 		// Channel history mode
@@ -320,6 +344,7 @@ func init() {
 	messageListCmd.Flags().String("latest", "", "Only messages before this ts")
 	messageListCmd.Flags().Int("max-body-chars", 8000, "Max content characters (-1 for unlimited)")
 	messageListCmd.Flags().Bool("include-reactions", false, "Include reactions")
+	messageListCmd.Flags().Bool("include-threads", false, "Also fetch new thread replies (use with --oldest)")
 
 	// message send flags
 	messageSendCmd.Flags().String("thread-ts", "", "Thread root ts to reply into")

--- a/internal/slack/messages.go
+++ b/internal/slack/messages.go
@@ -173,6 +173,137 @@ func FetchThread(ctx context.Context, client *api.Client, channelID, threadTS st
 	return messages, nil
 }
 
+// FetchChannelActivity returns new top-level messages AND new thread replies
+// since the given oldest timestamp. It scans recent channel history to find
+// threads with latest_reply > oldest, then fetches those thread replies.
+func FetchChannelActivity(ctx context.Context, client *api.Client, opts ChannelHistoryOpts) ([]types.CompactMessage, []types.ThreadUpdate, error) {
+	if opts.Limit <= 0 {
+		opts.Limit = 50
+	}
+	if opts.Limit > 200 {
+		opts.Limit = 200
+	}
+	if opts.MaxBodyChars == 0 {
+		opts.MaxBodyChars = 8000
+	}
+	oldest := opts.Oldest
+
+	// Step 1: Fetch channel history WITHOUT oldest filter to get recent thread parents.
+	scanParams := map[string]string{
+		"channel": opts.ChannelID,
+		"limit":   strconv.Itoa(opts.Limit),
+	}
+	if opts.Latest != "" {
+		scanParams["latest"] = opts.Latest
+	}
+
+	resp, err := client.Call(ctx, "conversations.history", scanParams)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rawMsgs := api.GetSlice(resp["messages"])
+	var newMessages []types.CompactMessage
+	var threadUpdates []types.ThreadUpdate
+
+	for _, m := range rawMsgs {
+		raw, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		ts := api.GetStringFromMap(raw, "ts")
+		latestReply := api.GetStringFromMap(raw, "latest_reply")
+		replyCount := api.GetIntFromMap(raw, "reply_count")
+
+		// New top-level message
+		if oldest == "" || ts > oldest {
+			newMessages = append(newMessages, *parseRawMessage(opts.ChannelID, raw, opts.MaxBodyChars, opts.IncludeReactions))
+		}
+
+		// Thread with new replies (parent may be old, but replies are new)
+		if replyCount > 0 && latestReply != "" && oldest != "" && latestReply > oldest {
+			// Fetch only new replies using oldest parameter
+			threadReplies, err := fetchThreadRepliesSince(ctx, client, opts.ChannelID, ts, oldest, opts.IncludeReactions, opts.MaxBodyChars)
+			if err != nil {
+				continue
+			}
+			if len(threadReplies) > 0 {
+				parentMsg := parseRawMessage(opts.ChannelID, raw, 200, false) // short preview
+				update := types.ThreadUpdate{
+					ThreadTS:     ts,
+					ParentAuthor: parentMsg.Author,
+					NewReplies:   threadReplies,
+				}
+				if parentMsg.Content != "" {
+					preview := parentMsg.Content
+					if len(preview) > 200 {
+						preview = preview[:200] + "..."
+					}
+					update.ParentPreview = preview
+				}
+				threadUpdates = append(threadUpdates, update)
+			}
+		}
+	}
+
+	// Sort new messages chronologically
+	sort.Slice(newMessages, func(i, j int) bool {
+		return newMessages[i].TS < newMessages[j].TS
+	})
+
+	return newMessages, threadUpdates, nil
+}
+
+// fetchThreadRepliesSince fetches thread replies newer than oldest timestamp.
+func fetchThreadRepliesSince(ctx context.Context, client *api.Client, channelID, threadTS, oldest string, includeReactions bool, maxBodyChars int) ([]types.CompactMessage, error) {
+	var replies []types.CompactMessage
+	cursor := ""
+
+	for {
+		params := map[string]string{
+			"channel": channelID,
+			"ts":      threadTS,
+			"oldest":  oldest,
+			"limit":   "200",
+		}
+		if cursor != "" {
+			params["cursor"] = cursor
+		}
+
+		resp, err := client.Call(ctx, "conversations.replies", params)
+		if err != nil {
+			return nil, err
+		}
+
+		rawMsgs := api.GetSlice(resp["messages"])
+		for _, m := range rawMsgs {
+			if raw, ok := m.(map[string]interface{}); ok {
+				msgTS := api.GetStringFromMap(raw, "ts")
+				// Skip the thread parent itself, only include actual replies
+				if msgTS == threadTS {
+					continue
+				}
+				// Only include replies newer than oldest
+				if msgTS > oldest {
+					replies = append(replies, *parseRawMessage(channelID, raw, maxBodyChars, includeReactions))
+				}
+			}
+		}
+
+		cursor = api.ExtractCursor(resp)
+		if cursor == "" {
+			break
+		}
+	}
+
+	sort.Slice(replies, func(i, j int) bool {
+		return replies[i].TS < replies[j].TS
+	})
+
+	return replies, nil
+}
+
 // SendMessage posts a message to a channel, optionally in a thread.
 func SendMessage(ctx context.Context, client *api.Client, channelID, text, threadTS string) (*types.CompactMessage, error) {
 	params := map[string]string{
@@ -249,11 +380,12 @@ func parseRawMessage(channelID string, raw map[string]interface{}, maxBodyChars 
 	}
 
 	msg := &types.CompactMessage{
-		ChannelID:  channelID,
-		TS:         ts,
-		ThreadTS:   threadTS,
-		ReplyCount: api.GetIntFromMap(raw, "reply_count"),
-		Content:    content,
+		ChannelID:   channelID,
+		TS:          ts,
+		ThreadTS:    threadTS,
+		ReplyCount:  api.GetIntFromMap(raw, "reply_count"),
+		LatestReply: api.GetStringFromMap(raw, "latest_reply"),
+		Content:     content,
 	}
 
 	if user != "" || botID != "" {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -47,14 +47,23 @@ type APIResponse map[string]interface{}
 
 // CompactMessage is the token-efficient output format for messages.
 type CompactMessage struct {
-	ChannelID  string           `json:"channel_id,omitempty"`
-	TS         string           `json:"ts"`
-	ThreadTS   string           `json:"thread_ts,omitempty"`
-	ReplyCount int              `json:"reply_count,omitempty"`
-	Author     *MessageAuthor   `json:"author,omitempty"`
-	Content    string           `json:"content,omitempty"`
-	Files      []CompactFile    `json:"files,omitempty"`
-	Reactions  []CompactReaction `json:"reactions,omitempty"`
+	ChannelID   string           `json:"channel_id,omitempty"`
+	TS          string           `json:"ts"`
+	ThreadTS    string           `json:"thread_ts,omitempty"`
+	ReplyCount  int              `json:"reply_count,omitempty"`
+	LatestReply string           `json:"latest_reply,omitempty"`
+	Author      *MessageAuthor   `json:"author,omitempty"`
+	Content     string           `json:"content,omitempty"`
+	Files       []CompactFile    `json:"files,omitempty"`
+	Reactions   []CompactReaction `json:"reactions,omitempty"`
+}
+
+// ThreadUpdate represents new replies in a thread since a given time.
+type ThreadUpdate struct {
+	ThreadTS      string           `json:"thread_ts"`
+	ParentAuthor  *MessageAuthor   `json:"parent_author,omitempty"`
+	ParentPreview string           `json:"parent_preview,omitempty"`
+	NewReplies    []CompactMessage `json:"new_replies"`
 }
 
 // MessageAuthor identifies who sent a message.


### PR DESCRIPTION
## Summary
- Adds `--include-threads` flag to `message list` that, when combined with `--oldest`, scans recent channel history for threads with new replies and fetches them
- Exposes `latest_reply` field on all message output so callers can see thread activity timestamps
- Adds `ThreadUpdate` type with parent preview and new replies for structured thread activity output
- Updates SLACK_CLI_USAGE.md and README.md with new flag documentation and agent workflow guidance

## Test plan
- [x] Verified `slack-cli message list <channel> --oldest <ts> --limit 50 --include-threads` returns both new top-level messages and thread updates
- [ ] Verify `--include-threads` without `--oldest` falls through to normal history mode
- [ ] Verify `latest_reply` appears in standard `message list` output for thread parents

🤖 Generated with [Claude Code](https://claude.com/claude-code)