### PR TITLE
Add semver label-based release workflow

### DIFF
--- a/.github/workflows/ci-require-labels.yml
+++ b/.github/workflows/ci-require-labels.yml
@@ -1,0 +1,13 @@
+name: CI Require Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+run-name: CI Require Labels by @${{ github.actor }} ${{ github.sha }}
+permissions:
+  pull-requests: write
+jobs:
+  require-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require Labels
+        uses: nullify-platform/github-actions/actions/require-labels@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,34 @@
 name: Release
-
 on:
   push:
-    tags:
-      - 'v*'
-
+    branches:
+      - main
+concurrency:
+  group: release
+  cancel-in-progress: true
+run-name: Release by @${{ github.actor }} ${{ github.sha }}
 permissions:
   contents: write
-
+  pull-requests: read
 jobs:
+  get-version:
+    name: Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get Release Version
+        id: get-version
+        uses: nullify-platform/github-actions/actions/release-version@main
+      - run: |
+          echo "**Version:** ${{ steps.get-version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+
   build:
+    if: ${{ needs.get-version.outputs.version != 'undefined' }}
+    needs: [get-version]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -42,9 +61,11 @@ jobs:
           path: slack-cli-${{ matrix.goos }}-${{ matrix.goarch }}
 
   release:
-    needs: build
+    needs: [get-version, build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
@@ -53,4 +74,4 @@ jobs:
       - name: Create release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create ${{ github.ref_name }} artifacts/* --repo ${{ github.repository }} --title "${{ github.ref_name }}" --generate-notes
+        run: gh release create "v${{ needs.get-version.outputs.version }}" artifacts/* --repo ${{ github.repository }} --title "v${{ needs.get-version.outputs.version }}" --generate-notes


### PR DESCRIPTION
## Summary
- Replace tag-based releases with automatic releases triggered on merge to main
- Version is determined from PR labels (`patch`, `minor`, `major`) using the shared `nullify-platform/github-actions/actions/release-version` action
- Add `ci-require-labels` workflow to block PRs from merging without a semver label
- Added repo ruleset requiring the `require-labels` check to pass

## Test plan
- [ ] Open a PR and verify the `require-labels` check blocks merge without a label
- [ ] Add a `patch` label and verify the check passes
- [ ] Merge this PR with a `patch` label and verify the release workflow creates `v0.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)