### PR TITLE
Add file upload, download, and info commands

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/nullify/slack-cli/internal/output"
+	"github.com/nullify/slack-cli/internal/slack"
+	"github.com/nullify/slack-cli/internal/urlparse"
+	"github.com/spf13/cobra"
+)
+
+var fileCmd = &cobra.Command{
+	Use:   "file",
+	Short: "Inspect, upload, and download Slack file attachments",
+}
+
+var fileInfoCmd = &cobra.Command{
+	Use:   "info <file-id>",
+	Short: "Fetch metadata for a Slack file",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+		info, err := slack.GetFileInfo(cmd.Context(), client, args[0])
+		if err != nil {
+			return err
+		}
+		return output.PrintJSON(info)
+	},
+}
+
+var fileDownloadCmd = &cobra.Command{
+	Use:   "download <file-id>",
+	Short: "Download a Slack file to stdout or --output <path>",
+	Long: `Download a Slack file attachment using its file ID.
+
+The file content is written to stdout by default, or to a file with --output.
+File metadata (name, mimetype, size) is printed to stderr so stdout stays clean for piping.
+
+Examples:
+  slack-cli file download F12345678 > image.png
+  slack-cli file download F12345678 --output image.png`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outputPath, _ := cmd.Flags().GetString("output")
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		info, err := slack.GetFileInfo(cmd.Context(), client, args[0])
+		if err != nil {
+			return err
+		}
+		if info.URLPrivate == "" {
+			return fmt.Errorf("file %s has no downloadable URL (it may be a snippet or external file)", args[0])
+		}
+
+		fmt.Fprintf(os.Stderr, "downloading: %s (%s, %d bytes)\n", info.Name, info.Mimetype, info.Size)
+
+		body, _, err := client.Download(cmd.Context(), info.URLPrivate)
+		if err != nil {
+			return err
+		}
+		defer body.Close()
+
+		var dst io.Writer = os.Stdout
+		if outputPath != "" {
+			f, err := os.Create(outputPath)
+			if err != nil {
+				return fmt.Errorf("creating output file: %w", err)
+			}
+			defer f.Close()
+			dst = f
+		}
+
+		if _, err := io.Copy(dst, body); err != nil {
+			return fmt.Errorf("writing file content: %w", err)
+		}
+
+		if outputPath != "" {
+			fmt.Fprintf(os.Stderr, "saved to: %s\n", outputPath)
+		}
+		return nil
+	},
+}
+
+var fileUploadCmd = &cobra.Command{
+	Use:   "upload <channel> <file-path>",
+	Short: "Upload a file to a Slack channel or thread",
+	Long: `Upload a local file to a Slack channel using the files.getUploadURLExternal API.
+
+The channel can be a channel ID (C...), channel name (#general), or user ID for DMs.
+
+Examples:
+  slack-cli file upload C01234ABC ./report.pdf --message "Here is the report"
+  slack-cli file upload "#general" ./image.png --thread-ts 1234567890.123456
+  slack-cli file upload C01234ABC ./data.csv --title "Q1 Data" --message "See attached"`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		message, _ := cmd.Flags().GetString("message")
+		threadTS, _ := cmd.Flags().GetString("thread-ts")
+		title, _ := cmd.Flags().GetString("title")
+		filename, _ := cmd.Flags().GetString("filename")
+
+		client, err := getClient()
+		if err != nil {
+			return err
+		}
+
+		target := urlparse.ParseMsgTarget(args[0])
+		channelID, err := resolveTargetToChannel(cmd, client, target)
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintf(os.Stderr, "uploading: %s\n", args[1])
+
+		info, err := slack.UploadFile(cmd.Context(), client, slack.UploadOpts{
+			FilePath:  args[1],
+			ChannelID: channelID,
+			Filename:  filename,
+			Title:     title,
+			Message:   message,
+			ThreadTS:  threadTS,
+		})
+		if err != nil {
+			return err
+		}
+
+		return output.PrintJSON(info)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(fileCmd)
+	fileCmd.AddCommand(fileInfoCmd, fileDownloadCmd, fileUploadCmd)
+
+	fileDownloadCmd.Flags().String("output", "", "Write file content to this path instead of stdout")
+
+	fileUploadCmd.Flags().String("message", "", "Optional message to post alongside the file")
+	fileUploadCmd.Flags().String("thread-ts", "", "Thread root ts to upload into a thread")
+	fileUploadCmd.Flags().String("title", "", "Display title for the file (defaults to filename)")
+	fileUploadCmd.Flags().String("filename", "", "Override the filename sent to Slack (defaults to basename of file-path)")
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -132,6 +132,53 @@ func (c *Client) Call(ctx context.Context, method string, params map[string]stri
 	return nil, fmt.Errorf("max retries exceeded for %s", method)
 }
 
+// UploadToURL POSTs raw file content to a pre-signed Slack upload URL.
+// The upload URL itself is authorization — no Slack auth headers are sent.
+func (c *Client) UploadToURL(ctx context.Context, uploadURL string, r io.Reader, size int64, contentType string) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", uploadURL, r)
+	if err != nil {
+		return fmt.Errorf("building upload request: %w", err)
+	}
+	req.ContentLength = size
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("uploading file: %w", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("upload failed with HTTP %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}
+
+// Download performs an authenticated GET on a private Slack URL (e.g. url_private)
+// and returns the response body. The caller must close it.
+func (c *Client) Download(ctx context.Context, privateURL string) (io.ReadCloser, string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", privateURL, nil)
+	if err != nil {
+		return nil, "", fmt.Errorf("building download request: %w", err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("Authorization", "Bearer "+c.auth.Token)
+	if c.auth.Mode == types.AuthBrowser {
+		req.Header.Set("Cookie", "d="+url.QueryEscape(c.auth.Cookie))
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, "", fmt.Errorf("downloading file: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, "", fmt.Errorf("download failed with HTTP %d", resp.StatusCode)
+	}
+	return resp.Body, resp.Header.Get("Content-Type"), nil
+}
+
 func parseRetryAfter(header string, defaultSec int) int {
 	if header == "" {
 		return defaultSec

--- a/internal/slack/files.go
+++ b/internal/slack/files.go
@@ -1,0 +1,115 @@
+package slack
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/nullify/slack-cli/internal/api"
+	"github.com/nullify/slack-cli/internal/types"
+)
+
+// UploadOpts controls how a file is uploaded to Slack.
+type UploadOpts struct {
+	FilePath  string
+	ChannelID string
+	Filename  string // overrides the base name of FilePath
+	Title     string
+	Message   string
+	ThreadTS  string
+}
+
+// UploadFile uploads a local file to Slack using the three-step external upload API:
+// files.getUploadURLExternal → POST to signed URL → files.completeUploadExternal.
+func UploadFile(ctx context.Context, client *api.Client, opts UploadOpts) (*types.FileInfo, error) {
+	stat, err := os.Stat(opts.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading file: %w", err)
+	}
+
+	filename := opts.Filename
+	if filename == "" {
+		filename = filepath.Base(opts.FilePath)
+	}
+	title := opts.Title
+	if title == "" {
+		title = filename
+	}
+
+	contentType := mime.TypeByExtension(filepath.Ext(filename))
+	if contentType == "" {
+		contentType = "application/octet-stream"
+	}
+
+	// Step 1: get a pre-signed upload URL and file ID.
+	urlResp, err := client.Call(ctx, "files.getUploadURLExternal", map[string]string{
+		"filename": filename,
+		"length":   strconv.FormatInt(stat.Size(), 10),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("files.getUploadURLExternal: %w", err)
+	}
+	uploadURL := api.GetString(urlResp["upload_url"])
+	fileID := api.GetString(urlResp["file_id"])
+	if uploadURL == "" || fileID == "" {
+		return nil, fmt.Errorf("files.getUploadURLExternal: missing upload_url or file_id in response")
+	}
+
+	// Step 2: stream file content to the pre-signed URL.
+	f, err := os.Open(opts.FilePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening file: %w", err)
+	}
+	defer f.Close()
+
+	if err := client.UploadToURL(ctx, uploadURL, f, stat.Size(), contentType); err != nil {
+		return nil, err
+	}
+
+	// Step 3: complete the upload, optionally sharing to a channel.
+	filesParam, err := json.Marshal([]map[string]string{{"id": fileID, "title": title}})
+	if err != nil {
+		return nil, fmt.Errorf("encoding files param: %w", err)
+	}
+	completeParams := map[string]string{
+		"files":           string(filesParam),
+		"channel_id":      opts.ChannelID,
+		"initial_comment": opts.Message,
+		"thread_ts":       opts.ThreadTS,
+	}
+	if _, err := client.Call(ctx, "files.completeUploadExternal", completeParams); err != nil {
+		return nil, fmt.Errorf("files.completeUploadExternal: %w", err)
+	}
+
+	return GetFileInfo(ctx, client, fileID)
+}
+
+// GetFileInfo calls files.info and returns compact file metadata.
+func GetFileInfo(ctx context.Context, client *api.Client, fileID string) (*types.FileInfo, error) {
+	resp, err := client.Call(ctx, "files.info", map[string]string{"file": fileID})
+	if err != nil {
+		return nil, fmt.Errorf("files.info: %w", err)
+	}
+
+	f := api.GetMap(resp["file"])
+	if f == nil {
+		return nil, fmt.Errorf("files.info: missing file object in response")
+	}
+
+	return &types.FileInfo{
+		ID:         api.GetStringFromMap(f, "id"),
+		Name:       api.GetStringFromMap(f, "name"),
+		Title:      api.GetStringFromMap(f, "title"),
+		Mimetype:   api.GetStringFromMap(f, "mimetype"),
+		Filetype:   api.GetStringFromMap(f, "filetype"),
+		Size:       api.GetIntFromMap(f, "size"),
+		URLPrivate: api.GetStringFromMap(f, "url_private"),
+		Permalink:  api.GetStringFromMap(f, "permalink"),
+		Created:    int64(api.GetIntFromMap(f, "created")),
+		User:       api.GetStringFromMap(f, "user"),
+	}, nil
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -82,6 +82,20 @@ type CompactFile struct {
 	Size      int    `json:"size,omitempty"`
 }
 
+// FileInfo is the token-efficient file metadata from files.info.
+type FileInfo struct {
+	ID          string `json:"id"`
+	Name        string `json:"name,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Mimetype    string `json:"mimetype,omitempty"`
+	Filetype    string `json:"filetype,omitempty"`
+	Size        int    `json:"size,omitempty"`
+	URLPrivate  string `json:"url_private,omitempty"`
+	Permalink   string `json:"permalink,omitempty"`
+	Created     int64  `json:"created,omitempty"`
+	User        string `json:"user,omitempty"`
+}
+
 // CompactReaction is the token-efficient reaction format.
 type CompactReaction struct {
 	Name  string   `json:"name"`


### PR DESCRIPTION
## Summary

- **`file info <file-id>`** — fetch compact file metadata from `files.info` (id, name, mimetype, size, `url_private`, permalink, created, user)
- **`file download <file-id>`** — download a private Slack file attachment to stdout or a local path (`--output`) via authenticated GET on `url_private`
- **`file upload <channel> <file-path>`** — upload a local file to a channel or thread using Slack's three-step external upload API

## Upload flow

1. `files.getUploadURLExternal` — get a pre-signed URL and file ID
2. POST raw file bytes to the signed URL (no Slack auth needed; MIME type detected from extension)
3. `files.completeUploadExternal` — share to channel with optional message and thread

## Flags

| Command | Flag | Description |
|---|---|---|
| `download` | `--output <path>` | Write to file instead of stdout |
| `upload` | `--message` | Text posted alongside the file |
| `upload` | `--thread-ts` | Upload into a thread |
| `upload` | `--title` | Display title (defaults to filename) |
| `upload` | `--filename` | Override the filename Slack receives |

Channel resolution for `upload` uses the existing target parser — channel names (`#general`), IDs (`C...`), and user IDs all work.

## Test plan

- [ ] `file info <file-id>` returns JSON metadata for a known file
- [ ] `file download <file-id>` pipes binary content to stdout cleanly
- [ ] `file download <file-id> --output out.png` writes file and prints path to stderr
- [ ] `file upload <channel> ./file.pdf` completes without error and returns file metadata JSON
- [ ] `file upload <channel> ./file.pdf --thread-ts <ts> --message "text"` posts into thread with message
- [ ] Channel name (`#general`), channel ID, and user ID all resolve correctly for upload