### PR TITLE
feat: expose file id in message output

### DIFF
--- a/SLACK_CLI_USAGE.md
+++ b/SLACK_CLI_USAGE.md
@@ -41,7 +41,7 @@ Messages are returned in chronological order (oldest first). Each message includ
 - `latest_reply` — timestamp of the most recent reply (only on thread root messages)
 - `author.user_id` — who sent it
 - `content` — message text
-- `files` — attached file metadata (if any)
+- `files` — attached file metadata (if any), each with `id`, `name`, `mimetype`, `size`, and `permalink` (see §10 to download)
 
 ### 3. Read a thread
 
@@ -125,6 +125,20 @@ slack-cli search messages 'deploy' --channel '#engineering' --user '@jules' --af
 slack-cli search files 'report' --limit 10
 ```
 
+### 10. Inspect and download file attachments
+
+Each entry in a message's `files` array has an `id` (e.g. `F0B9ZKGUQ85`). Fetch its metadata:
+
+```
+slack-cli file info F0B9ZKGUQ85
+```
+
+Download the bytes to a local path (omit `--output` to stream to stdout; metadata goes to stderr):
+
+```
+slack-cli file download F0B9ZKGUQ85 --output /tmp/attachment.png
+```
+
 ## Sending and Modifying Messages
 
 ### Send a message to a channel
@@ -192,6 +206,15 @@ slack-cli message react add '#channel-name' thumbsup --ts 1772065778.676219
 slack-cli message react remove '#channel-name' thumbsup --ts 1772065778.676219
 ```
 
+### Upload a file
+
+Upload a local file to a channel or thread:
+
+```
+slack-cli file upload '#channel-name' /tmp/result.png --message 'Here is the output'
+slack-cli file upload '#channel-name' /tmp/result.png --thread-ts 1772065778.676219
+```
+
 ## Channel Management
 
 ### Create a channel
@@ -214,8 +237,9 @@ slack-cli channel invite --channel '#channel-name' --users 'U01234,U56789'
 3. For any message with `reply_count > 0` — `slack-cli message list '#channel' --thread-ts <ts>` to read the thread
 4. To poll for new activity since a known timestamp — `slack-cli message list '#channel' --oldest <ts> --include-threads` to catch both new messages and new thread replies
 5. `slack-cli user get <user_id>` — resolve user IDs as needed
-6. `slack-cli message send '#channel' 'response'` — reply to the channel
-7. `slack-cli message send '#channel' 'response' --thread-ts <ts>` — reply in a specific thread
+6. For a message with a `files` attachment — `slack-cli file download <file_id> --output <path>` to fetch it
+7. `slack-cli message send '#channel' 'response'` — reply to the channel
+8. `slack-cli message send '#channel' 'response' --thread-ts <ts>` — reply in a specific thread
 
 ## Notes
 

--- a/internal/slack/messages.go
+++ b/internal/slack/messages.go
@@ -397,6 +397,7 @@ func parseRawMessage(channelID string, raw map[string]interface{}, maxBodyChars 
 		for _, f := range files {
 			if fm, ok := f.(map[string]interface{}); ok {
 				msg.Files = append(msg.Files, types.CompactFile{
+					ID:        api.GetStringFromMap(fm, "id"),
 					Name:      api.GetStringFromMap(fm, "name"),
 					Title:     api.GetStringFromMap(fm, "title"),
 					Mimetype:  api.GetStringFromMap(fm, "mimetype"),

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -74,6 +74,7 @@ type MessageAuthor struct {
 
 // CompactFile is the token-efficient file metadata.
 type CompactFile struct {
+	ID        string `json:"id,omitempty"`
 	Mimetype  string `json:"mimetype,omitempty"`
 	Mode      string `json:"mode,omitempty"`
 	Name      string `json:"name,omitempty"`


### PR DESCRIPTION
The `files` array on `message list` / `message get` was missing the file `id` — it only carried name, mimetype, permalink and size. That left the `file download` and `file info` commands unreachable for attachments discovered through a message, since both take a file id and the only place the id appeared was buried in the permalink URL.

This adds `id` to the compact file metadata so the download path works end to end: read a message, grab the attachment id, pull the bytes with `file download`.

Also documents the `file info` / `file download` / `file upload` commands in the usage guide — they existed but werent written up anywhere.

## Test
- `go build ./...`, `go vet ./...` clean
- Verified `file download`/`info`/`upload` help and that message output now includes the id field

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Nullify-Platform/codesmith/slack-cli/pr/12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783833456&installation_id=90420261&pr_number=12&repository=Nullify-Platform%2Fslack-cli&return_to=https%3A%2F%2Fgithub.com%2FNullify-Platform%2Fslack-cli%2Fpull%2F12&signature=140526557d619e8e314c1b1147ca274cf0acb0a320ca20aa1ab66aca6b6d69ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->